### PR TITLE
Upgrade Python and Django

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install --upgrade flake8 isort
+      - run: flake8 .
+      - run: isort .

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 settings.py
 /paramiko.log
 /staticfiles
+/static
 /data

--- a/finder/templates/api.html
+++ b/finder/templates/api.html
@@ -153,7 +153,7 @@
       </dd>
       <dt>Get one page of boundaries from a boundary set</dt>
       <dd>
-        <a class="example" href="/boundaries/toronto-wards/?format=apibrowser">/boundaries/toronto-wards/</a>
+        <a class="example" href="/boundaries/toronto-wards-2018/?format=apibrowser">/boundaries/toronto-wards-2018/</a>
         <p>To see what boundary sets are available, consult the <a href="#boundaryset">boundary sets</a> endpoint.</p>
       </dd>
       <dt>Get one page of boundaries from multiple boundary sets (comma-separated)</dt>
@@ -205,15 +205,15 @@
     <dl>
       <dt>Get all simple shapes from a boundary set</dt>
       <dd>
-        <a class="example" href="/boundaries/toronto-wards/simple_shape?format=apibrowser">/boundaries/toronto-wards/simple_shape</a>
+        <a class="example" href="/boundaries/toronto-wards-2018/simple_shape?format=apibrowser">/boundaries/toronto-wards-2018/simple_shape</a>
       </dd>
       <dt>Get all original shapes from a boundary set</dt>
       <dd>
-        <a class="example" href="/boundaries/toronto-wards/shape?format=apibrowser">/boundaries/toronto-wards/shape</a>
+        <a class="example" href="/boundaries/toronto-wards-2018/shape?format=apibrowser">/boundaries/toronto-wards-2018/shape</a>
       </dd>
       <dt>Get all centroids from a boundary set</dt>
       <dd>
-        <a class="example" href="/boundaries/toronto-wards/centroid?format=apibrowser">/boundaries/toronto-wards/centroid</a>
+        <a class="example" href="/boundaries/toronto-wards-2018/centroid?format=apibrowser">/boundaries/toronto-wards-2018/centroid</a>
       </dd>
       <dt>Get one boundary's simple shape</dt>
       <dd>
@@ -281,7 +281,7 @@
       </dd>
       <dt>Get the representatives for one boundary</dt>
       <dd>
-        <a class="example" href="/boundaries/toronto-wards/etobicoke-north-1/representatives/?format=apibrowser">/boundaries/toronto-wards/etobicoke-north-1/representatives/</a>
+        <a class="example" href="/boundaries/toronto-wards-2018/etobicoke-north-1/representatives/?format=apibrowser">/boundaries/toronto-wards-2018/etobicoke-north-1/representatives/</a>
       </dd>
       <dt>Get the representatives for multiple boundaries (comma-separated)</dt>
       <dd>

--- a/finder/templates/api.html
+++ b/finder/templates/api.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}API Reference | Represent Elected Officials and Electoral Districts API for Canada{% endblock %}
 {% block bodyattributes %}id="api"{% endblock %}

--- a/finder/templates/data.html
+++ b/finder/templates/data.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "CSV Downloads" %} | {% trans "Represent Elected Officials and Electoral Districts API for Canada" %}{% endblock %}
 {% block bodyattributes %}id="data"{% endblock %}

--- a/finder/templates/demo.html
+++ b/finder/templates/demo.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Find Your Canadian Representatives with the Represent API" %}{% endblock %}
 

--- a/finder/templates/government.html
+++ b/finder/templates/government.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "For Government" %} | {% trans "Represent Elected Officials and Electoral Districts API for Canada" %}{% endblock %}
 {% block bodyattributes %}id="government"{% endblock %}

--- a/finder/templates/index.html
+++ b/finder/templates/index.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Represent Elected Officials and Electoral Districts API for Canada" %}{% endblock %}
 

--- a/finder/urls.py
+++ b/finder/urls.py
@@ -1,15 +1,15 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.i18n import JavaScriptCatalog
 
 from finder import views
 
 urlpatterns = [
-    url(r'^jsi18n/$', JavaScriptCatalog.as_view(packages=['finder']), name='javascript-catalog'),
-    url(r'^setlang/$', views.set_language, name='set_language'),
-    url(r'^api/$', views.api, name='apidoc'),
-    url(r'^data/$', views.data, name='data'),
-    url(r'^demo/$', views.demo, name='demo'),
-    url(r'^government/$', views.government, name='government'),
-    url(r'^privacy/$', views.privacy, name='privacy'),
-    url(r'^$', views.index),
+    path('jsi18n/', JavaScriptCatalog.as_view(packages=['finder']), name='javascript-catalog'),
+    path('setlang/', views.set_language, name='set_language'),
+    path('api/', views.api, name='apidoc'),
+    path('data/', views.data, name='data'),
+    path('demo/', views.demo, name='demo'),
+    path('government/', views.government, name='government'),
+    path('privacy/', views.privacy, name='privacy'),
+    path('', views.index),
 ]

--- a/finder/views.py
+++ b/finder/views.py
@@ -1,8 +1,8 @@
 from django import http
 from django.conf import settings
 from django.shortcuts import render
-from django.utils.translation import check_for_language
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import check_for_language
 
 
 def index(request):

--- a/finder/views.py
+++ b/finder/views.py
@@ -2,7 +2,7 @@ from django import http
 from django.conf import settings
 from django.shortcuts import render
 from django.utils.translation import check_for_language
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 
 def index(request):
@@ -36,9 +36,9 @@ def _render(template_name, request):
 # @see django/views/i18n.py
 def set_language(request):
     next = request.GET.get('next')
-    if not is_safe_url(url=next, host=request.get_host()):
-        next = request.META.get('HTTP_REFERER')
-        if not is_safe_url(url=next, host=request.get_host()):
+    if not url_has_allowed_host_and_scheme(url=next, host=request.get_host()):
+        next = request.headers.get('referer')
+        if not url_has_allowed_host_and_scheme(url=next, host=request.get_host()):
             next = '/'
     response = http.HttpResponseRedirect(next)
     lang_code = request.GET.get('language')

--- a/represent/default_settings.py
+++ b/represent/default_settings.py
@@ -62,6 +62,11 @@ STATIC_URL = '/static/'
 ROOT_URLCONF = 'represent.urls'
 WSGI_APPLICATION = 'represent.wsgi.application'
 
+# Default primary key field type
+# https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
 LANGUAGES = (
     ('en', 'English'),
     ('fr', 'Français'),

--- a/represent/default_settings.py
+++ b/represent/default_settings.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/represent/default_settings.py
+++ b/represent/default_settings.py
@@ -120,3 +120,8 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     },
 }
+
+if 'GDAL_LIBRARY_PATH' in os.environ:
+    GDAL_LIBRARY_PATH = os.getenv('GDAL_LIBRARY_PATH')
+if 'GEOS_LIBRARY_PATH' in os.environ:
+    GEOS_LIBRARY_PATH = os.getenv('GEOS_LIBRARY_PATH')

--- a/represent/urls.py
+++ b/represent/urls.py
@@ -1,5 +1,7 @@
-from django.urls import include, path, re_path
+from django.conf import settings
 from django.contrib import admin
+from django.contrib.staticfiles import views
+from django.urls import include, path, re_path
 
 admin.autodiscover()
 
@@ -10,3 +12,8 @@ urlpatterns = [
     path('', include('postcodes.urls')),
     path('', include('finder.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [
+        re_path(r"^static/(?P<path>.*)$", views.serve),
+    ]

--- a/represent/urls.py
+++ b/represent/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url('', include('boundaries.urls')),
-    url('', include('representatives.urls')),
-    url('', include('postcodes.urls')),
-    url('', include('finder.urls')),
+    re_path(r'^admin/', admin.site.urls),
+    path('', include('boundaries.urls')),
+    path('', include('representatives.urls')),
+    path('', include('postcodes.urls')),
+    path('', include('finder.urls')),
 ]

--- a/represent/wsgi.py
+++ b/represent/wsgi.py
@@ -8,7 +8,9 @@ https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
 import os
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "represent.settings")
 
-from django.core.wsgi import get_wsgi_application
+from django.core.wsgi import get_wsgi_application  # noqa: E402
+
 application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-Django==1.11.29
-psycopg2-binary==2.7.4
+Django<5
+psycopg2-binary==2.9.9
 python3-memcached==1.51
-represent-boundaries==0.9.3
--e git+https://github.com/opennorth/represent-reps.git#egg=represent-representatives
--e git+https://github.com/opennorth/represent-postcodes.git#egg=represent-postcodes
+# represent-boundaries==0.9.3
+-e git+https://github.com/opennorth/represent-boundaries.git@upgrade#egg=represent-boundaries
+-e git+https://github.com/opennorth/represent-reps.git@upgrade#egg=represent-representatives
+-e git+https://github.com/opennorth/represent-postcodes.git@upgrade#egg=represent-postcodes
 
 # Server
 eventlet==0.31.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[isort]
+line_length = 119
+profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [isort]
 line_length = 119
 profile = black
+
+[flake8]
+max-line-length = 119

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load staticfiles %}<!DOCTYPE html>
+{% load i18n %}{% load static %}<!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
 <meta charset="utf-8">

--- a/templates/boundaries/apibrowser.html
+++ b/templates/boundaries/apibrowser.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{{ title.capitalize }} | Represent API{% endblock %}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,0 @@
-[flake8]
-ignore=E501
-# E501 line too long (X > 79 characters)


### PR DESCRIPTION
- chore: Run pyupgrade --py310-plus **/*.py and django-upgrade --target-version 4.2
- chore(templates): staticfiles -> static
- chore: Fix models.W042 warning
- settings: Make it easier to run in development on macOS
- build: Upgrade Django, psycopg2-binary and represent-* dependencies
